### PR TITLE
Reset body overflow property on unmount

### DIFF
--- a/src/Preloader/StyledPreloader.jsx
+++ b/src/Preloader/StyledPreloader.jsx
@@ -33,8 +33,12 @@ function Preloader({
     }
     return background;
   };
+  
+  useEffect(() => {
+    bodyScroll();
+    return () => bodyScroll();
+  }, []);
 
-  bodyScroll();
   useEffect(() => {
     if (customLoading === false) {
       setTimeout(() => {


### PR DESCRIPTION
Currently, the component does not clear the HTML body `overflow: hidden` property when unmounting it manually so I used `useEffect` to call the `bodyScroll()` function on mount and when it is about to be unmounted.