### PR TITLE
fix for Invalid Hook Call error

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,11 @@
     "loader",
     "react-component"
   ],
+  "peerDependencies": {
+    "react": "^16.8.6 || ^17"
+  },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "react": "^16.8.6",
     "styled-components": "^5.0.0-beta.0"
   },
   "homepage": "https://vamosgs.github.io/react-preloaders/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3735,14 +3735,6 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-
-lodash@^4.17.4:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-
 lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
@@ -4680,15 +4672,6 @@ react-test-renderer@^16.0.0-0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     react-is "^16.8.6"
-    scheduler "^0.13.6"
-
-react@^16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
     scheduler "^0.13.6"
 
 read-pkg-up@^2.0.0:


### PR DESCRIPTION
Fix for the Invalid Hook Call error https://github.com/VamOSGS/react-preloaders/issues/28

Problem:
The possible cause is that there is a duplicate React library.

Solution:
We transfer the React to the peerDependencies section

@VamOSGS 